### PR TITLE
added ignore patterns to c ext

### DIFF
--- a/lib/coverband_ext/version.rb
+++ b/lib/coverband_ext/version.rb
@@ -1,3 +1,3 @@
 module CoverbandExt
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
C extension takes ignore patterns into account.  This seems especially necessary on heroku where ruby itself is installed under the application's vendor directory.